### PR TITLE
Set the password during install

### DIFF
--- a/check_process
+++ b/check_process
@@ -4,6 +4,7 @@
 		path="/path"
 		admin="john"
 		is_public=1
+		password="1Strong-Password"
 	; Checks
 		pkg_linter=1
 		setup_sub_dir=0
@@ -22,4 +23,4 @@ Notification=none
 ;;; Upgrade options
 	; commit=CommitHash
 		name=Name and date of the commit.
-		manifest_arg=domain=DOMAIN&path=PATH&admin=USER&language=fr&is_public=1&password=pass&port=666&
+		manifest_arg=domain=DOMAIN&path=PATH&admin=USER&language=fr&is_public=1&password=1Strong-Password

--- a/manifest.json
+++ b/manifest.json
@@ -52,6 +52,15 @@
                     "fr": "Si cette case est cochée, Owncast sera accessible aux personnes n’ayant pas de compte. Vous pourrez changer ceci plus tard via la webadmin."
                 },
                 "default": true
+            },
+            {
+                "name": "password",
+                "type": "password",
+                "help": {
+                    "en": "Admin password and the steamkey.",
+                    "fr": "Mot de passe admin et streamkey."
+                },
+                "example": "Choose a password"
             }
         ]
     }

--- a/scripts/install
+++ b/scripts/install
@@ -126,6 +126,14 @@ ynh_script_progression --message="Configuring a systemd service..." --weight=1
 ynh_add_systemd_config
 
 #=================================================
+# SETUP APPLICATION PASSWORD
+#=================================================
+
+pushd $final_path
+	ynh_exec_as $app $final_path/owncast -streamkey $password
+popd
+
+#=================================================
 # GENERIC FINALIZATION
 #=================================================
 # SETUP LOGROTATE

--- a/scripts/install
+++ b/scripts/install
@@ -28,6 +28,7 @@ domain=$YNH_APP_ARG_DOMAIN
 path_url="/"
 is_public=$YNH_APP_ARG_IS_PUBLIC
 admin=$YNH_APP_ARG_ADMIN
+password=$YNH_APP_ARG_PASSWORD
 architecture=$(ynh_detect_arch)
 
 app=$YNH_APP_INSTANCE_NAME


### PR DESCRIPTION
Hi! With this PR, the install script set the password through `./owncast -streamkey`.

Unrelated : I was interested in packaging this app but didn't do it since 0.0.6 dropped the config file but I see here it's still working o/