### PR TITLE
Disable auth_header

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -65,6 +65,7 @@ ram.runtime = "50M"
 
     [resources.permissions]
     main.url = "/"
+    main.auth_header = false
 
     [resources.apt]
     packages = "ffmpeg"


### PR DESCRIPTION
## Problem

- Fix #23 

## Solution

- Disable `auth_header`

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
